### PR TITLE
Add link to Medium

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@
 - mvn clean install and mvn spring-boot:run
     - this will install all the dependencies you need
 
-Tutorial for this repo can be found on medium: 
+Tutorial for this repo can be found [on Medium](https://medium.com/analytics-vidhya/how-to-package-your-react-app-with-spring-boot-41432be974bc).


### PR DESCRIPTION
Thanks for the tutorial! The dad joke took me a second and then got the expected groan - well played. 😉 

One note on the article: In [the _Setup_ section](https://medium.com/analytics-vidhya/how-to-package-your-react-app-with-spring-boot-41432be974bc#ebd7), you're linking to [Oracle's JDK](https://www.oracle.com/java/technologies/javase-downloads.html), but that's not free to use in prod, so I recommend to link to [jdk.java.net](http://jdk.java.net/) instead.